### PR TITLE
fix: tildes en el input de nombre y apellido

### DIFF
--- a/src/components/InscripcionBox.tsx
+++ b/src/components/InscripcionBox.tsx
@@ -91,7 +91,7 @@ const InscripcionBox = () => {
             maxLength={100}
             className={`mt-2 w-full rounded-md border-2 border-topbar p-2 ${open ? 'text-topbar/25' : ''}`}
             placeholder="Nombre/s y apellido/s"
-            pattern="[a-zA-ZÀ-ÿ\u00f1\u00d1]+(\s*[a-zA-ZÀ-ÿ\u00f1\u00d1]*)*[a-zA-ZÀ-ÿ\u00f1\u00d1]+"
+            pattern="[a-zA-ZÀ-ÿ\u00f1\u00d1áéíóúÁÉÍÓÚ]+(\s*[a-zA-ZÀ-ÿ\u00f1\u00d1áéíóúÁÉÍÓÚ]*)*[a-zA-ZÀ-ÿ\u00f1\u00d1áéíóúÁÉÍÓÚ]+"
             title="Ingrese solo letras y espacios"
             required
           />


### PR DESCRIPTION
En este PR se soluciono el único y ultimo bug que se había generado en la parte del formulario. El error que se había identificado era la imposibilidad de envío de formulario tras tener un nombre y/O apellido con tildes. Ya eso fue solucionado y modificado correctamente. Cualquier otra consulta me avisan, gracias y buenas noches.